### PR TITLE
calico-tinygo: bump TinyGo 0.34.0 -> 0.39.0 (Go 1.25.11)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -169,17 +169,25 @@ blocks:
                     -target=wasip1 \
                     -gc=precise -opt=2 -scheduler=none \
                     -tags="nottinygc_envoy memoize_builders" \
+                    -ldflags="-extldflags=$CALICO_TINYGO_CTYPE_COMPAT" \
                     -o /out/fixture.wasm . && \
                   file /out/fixture.wasm | grep -q "WebAssembly"'
             - |
-              count=$(docker run --rm -v /tmp:/host ghcr.io/webassembly/wabt:1.0.36 \
-                wasm-objdump -x /host/fixture.wasm | grep -c "<- env.cre2_" || true)
+              # Dump imports first so a missing/corrupt wasm (wasm-objdump
+              # failure) fails the step, instead of grep defaulting count to a
+              # green 0. Only the grep count is allowed to be 0. Check the dump
+              # exit explicitly rather than relying on the shell's set -e.
+              if ! dump=$(docker run --rm -v /tmp:/host ghcr.io/webassembly/wabt:1.0.36 \
+                wasm-objdump -x /host/fixture.wasm); then
+                echo >&2 "FAIL: could not disassemble /tmp/fixture.wasm (missing or corrupt wasm)"
+                exit 1
+              fi
+              count=$(printf '%s\n' "$dump" | grep -c "<- env.cre2_" || true)
               if [ "${count:-0}" -ne 0 ]; then
                 echo >&2 "FAIL: fixture wasm has ${count} env.cre2_* imports (expected 0)"
                 echo >&2 "      A wasilibs/go-re2 bump likely lost TinyGo's bundled libcre2.a;"
                 echo >&2 "      this wasm would fail to load in Envoy with 'missing import: env.cre2_new'."
-                docker run --rm -v /tmp:/host ghcr.io/webassembly/wabt:1.0.36 \
-                  wasm-objdump -x /host/fixture.wasm | grep "<- env.cre2_" >&2 || true
+                printf '%s\n' "$dump" | grep "<- env.cre2_" >&2 || true
                 exit 1
               fi
               echo "OK: fixture wasm resolves cre2_* internally (no env.cre2_* imports)"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -173,12 +173,17 @@ blocks:
                     -o /out/fixture.wasm . && \
                   file /out/fixture.wasm | grep -q "WebAssembly"'
             - |
+              # ghcr.io/webassembly/wabt does not exist -- wabt only publishes
+              # binary tarballs, never a container image, on any registry.
+              # Fetch wasm-objdump directly instead.
+              curl -sfL "https://github.com/WebAssembly/wabt/releases/download/1.0.36/wabt-1.0.36-ubuntu-20.04.tar.gz" \
+                | tar xz -C /tmp --strip-components=2 wabt-1.0.36/bin/wasm-objdump
+            - |
               # Dump imports first so a missing/corrupt wasm (wasm-objdump
               # failure) fails the step, instead of grep defaulting count to a
               # green 0. Only the grep count is allowed to be 0. Check the dump
               # exit explicitly rather than relying on the shell's set -e.
-              if ! dump=$(docker run --rm -v /tmp:/host ghcr.io/webassembly/wabt:1.0.36 \
-                wasm-objdump -x /host/fixture.wasm); then
+              if ! dump=$(/tmp/wasm-objdump -x /tmp/fixture.wasm); then
                 echo >&2 "FAIL: could not disassemble /tmp/fixture.wasm (missing or corrupt wasm)"
                 exit 1
               fi

--- a/images/Makefile
+++ b/images/Makefile
@@ -133,10 +133,15 @@ push-calico-rust-build-manifests: var-require-one-of-CONFIRM-DRYRUN var-require-
 ################################################################################
 
 CALICO_TINYGO_IMAGETAG ?= latest
+# TinyGo version, read from the image's versions.yaml. Passed as a build-arg so
+# the Dockerfile can pull the matching upstream tinygo image as the source of a
+# compatible libstdc++ runtime (see calico-tinygo/Dockerfile). Deferred like
+# QEMU_VERSION above so yq runs only when a tinygo target needs it.
+CALICO_TINYGO_VERSION ?= $(shell yq -r .tinygo.version calico-tinygo/versions.yaml)
 
 .PHONY: calico-tinygo-image
 calico-tinygo-image: register
-	$(DOCKER_BUILD) -t $(CALICO_TINYGO):latest-$(ARCH) -f calico-tinygo/Dockerfile calico-tinygo/
+	$(DOCKER_BUILD) --build-arg TINYGO_VERSION=$(CALICO_TINYGO_VERSION) -t $(CALICO_TINYGO):latest-$(ARCH) -f calico-tinygo/Dockerfile calico-tinygo/
 	$(MAKE) BUILD_IMAGES=$(CALICO_TINYGO) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=$(CALICO_TINYGO_IMAGETAG)
 
 .PHONY: calico-tinygo-image-all

--- a/images/calico-tinygo/Dockerfile
+++ b/images/calico-tinygo/Dockerfile
@@ -1,3 +1,34 @@
+# ctypecompat build stage: supply the musl ctype/wctype functions (toupper,
+# tolower, the is*/isw* family and their _l locale variants) that TinyGo >= 0.38
+# stopped compiling into its bundled wasi-libc. The WAF wasm this image builds
+# links go-re2 v1.6.0's prebuilt static archives, which reference those as
+# externs; without them the link fails with "wasm-ld: undefined symbol: toupper".
+# go-re2 is frozen at v1.6.0 -- v1.8.0+ deleted the TinyGo static archives and
+# moved cre2 to a wazero runtime that Envoy's V8 cannot host, so we cannot bump
+# our way out of the missing symbols.
+#
+# The objects are lifted verbatim from TinyGo 0.34's prebuilt wasi-libc: its
+# pinned wasi-libc commit matches newer TinyGo (0.38 only dropped the ctype glob
+# from its libc build, the sources are unchanged), so they are ABI-compatible.
+# The source image is digest-pinned and `ar rcsD` writes deterministic archives,
+# so this extraction is reproducible. Built here rather than committed to the repo.
+#
+# TINYGO_VERSION is declared before any FROM so it is in scope for the final
+# stage's FROM below; the Makefile passes it from versions.yaml.
+ARG TINYGO_VERSION
+FROM calico/tinygo@sha256:9ff0bed2e3598f695a2fc6222be901eb0f3a0153549b82d28aa640c8487e1854 AS ctypecompat
+RUN set -eux; \
+    libc=/usr/local/tinygo/lib/wasi-libc/sysroot/lib/wasm32-wasi/libc.a; \
+    objs="__ctype_b_loc.o __ctype_get_mb_cur_max.o __ctype_tolower_loc.o __ctype_toupper_loc.o \
+          isalnum.o isalpha.o isascii.o isblank.o iscntrl.o isdigit.o isgraph.o islower.o \
+          isprint.o ispunct.o isspace.o isupper.o isxdigit.o \
+          iswalnum.o iswalpha.o iswblank.o iswcntrl.o iswctype.o iswdigit.o iswgraph.o \
+          iswlower.o iswprint.o iswpunct.o iswspace.o iswupper.o iswxdigit.o \
+          toascii.o tolower.o toupper.o towctrans.o wcswidth.o wctrans.o"; \
+    mkdir -p /work && cd /work; \
+    ar x "$libc" $objs; \
+    ar rcsD /libctypecompat.a $objs
+
 # calico/tinygo builds the coraza WAF wasm (TinyGo wasip1 target).
 #
 # Based on the upstream tinygo/tinygo image rather than a bare distro base:
@@ -37,17 +68,11 @@ RUN apt-get update && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 
-# ctype/wctype compat archive. TinyGo 0.38 rewrote how it builds its bundled
-# wasi-libc (builder/wasilibc.go) and dropped the musl ctype/*.c sources, so
-# toupper/tolower and the is*/isw*_l ctype family are no longer emitted into
-# libc.a. Prebuilt wasm archives that reference those as externs -- notably
-# wasilibs/go-re2 v1.6.0 (libc++.a) and wasilibs/nottinygc v0.7.1
-# (libmimalloc.a), the frozen archives WAF consumers must keep using -- then
-# fail to link with "wasm-ld: undefined symbol: toupper". Ship the objects
-# here (lifted verbatim from TinyGo 0.34's wasi-libc, identical pinned
-# wasi-libc commit) so downstream builds can append them to the wasm link via
-# `-ldflags=-extldflags=$CALICO_TINYGO_CTYPE_COMPAT`. See ctypecompat/README.md.
-COPY ctypecompat/libctypecompat.a /usr/local/lib/ctypecompat/libctypecompat.a
+# ctype/wctype compat archive, built in the stage above. Downstream WAF builds
+# append it to their TinyGo wasm link via
+# `-ldflags=-extldflags=$CALICO_TINYGO_CTYPE_COMPAT`; the test fixture under
+# test/fixture does the same in CI as a regression guard.
+COPY --from=ctypecompat /libctypecompat.a /usr/local/lib/ctypecompat/libctypecompat.a
 ENV CALICO_TINYGO_CTYPE_COMPAT=/usr/local/lib/ctypecompat/libctypecompat.a
 
 # GOPATH world-writable so downstream builds running as any uid (via

--- a/images/calico-tinygo/Dockerfile
+++ b/images/calico-tinygo/Dockerfile
@@ -1,68 +1,65 @@
-ARG TARGETARCH=${TARGETARCH}
-
-FROM almalinux:9 AS builder
+# calico/tinygo builds the coraza WAF wasm (TinyGo wasip1 target).
+#
+# Based on the upstream tinygo/tinygo image rather than a bare distro base:
+# TinyGo >= 0.38's release binary is dynamically linked against a newer
+# libstdc++/glibc than AlmaLinux 9 provides (the linux-arm64 binary needs
+# GLIBCXX_3.4.30 and GLIBC_2.36/2.38; EL9 ships glibc 2.34 + libstdc++ 3.4.29,
+# and EL9 has no runtime libstdc++.so.6 with 3.4.30 -- gcc-toolset only ships
+# static libs). The upstream image already carries a matching go + tinygo +
+# libstdc++ on both amd64 and arm64, so basing on it sidesteps the runtime
+# mismatch entirely. TINYGO_VERSION is passed by the Makefile from versions.yaml
+# so the base image tag selects the toolchain. This is a tag, not a digest, so it
+# fixes the toolchain version, not the exact bytes.
+ARG TINYGO_VERSION
+FROM tinygo/tinygo:${TINYGO_VERSION}
 
 ARG TARGETARCH
 
-# calico/tinygo ships amd64 + arm64 only — TinyGo upstream does not publish
-# Linux ppc64le/s390x tarballs. Wasm output is architecture-agnostic (Envoy
-# V8 JITs for the host arch at load time), but providing a native arm64
-# image lets developers on arm64 Linux hosts build without qemu emulation.
+# calico/tinygo ships amd64 + arm64 only -- TinyGo upstream does not publish
+# Linux ppc64le/s390x images. Wasm output is architecture-agnostic (Envoy V8
+# JITs for the host arch at load time), but providing a native arm64 image
+# lets developers on arm64 Linux hosts build without qemu emulation.
 RUN if [ "${TARGETARCH}" != "amd64" ] && [ "${TARGETARCH}" != "arm64" ]; then \
-        echo >&2 "error: calico/tinygo: TinyGo upstream does not publish a Linux ${TARGETARCH} tarball"; \
+        echo >&2 "error: calico/tinygo: unsupported arch ${TARGETARCH}"; \
         exit 1; \
     fi
 
-RUN dnf upgrade -y && dnf install -y epel-release && \
-    dnf install -y yq
+# Switch to root only for the setup steps that write root-owned paths, then
+# switch back to `tinygo` at the end so the image is not root by default.
+USER root
 
-RUN dnf install -y \
-        bsdtar \
+# The upstream image (Debian) lacks a few tools downstream builds/tests expect.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
         file \
         git \
         make \
         wget && \
-    dnf clean all
+    rm -rf /var/lib/apt/lists/*
 
-COPY versions.yaml /etc/versions.yaml
+# ctype/wctype compat archive. TinyGo 0.38 rewrote how it builds its bundled
+# wasi-libc (builder/wasilibc.go) and dropped the musl ctype/*.c sources, so
+# toupper/tolower and the is*/isw*_l ctype family are no longer emitted into
+# libc.a. Prebuilt wasm archives that reference those as externs -- notably
+# wasilibs/go-re2 v1.6.0 (libc++.a) and wasilibs/nottinygc v0.7.1
+# (libmimalloc.a), the frozen archives WAF consumers must keep using -- then
+# fail to link with "wasm-ld: undefined symbol: toupper". Ship the objects
+# here (lifted verbatim from TinyGo 0.34's wasi-libc, identical pinned
+# wasi-libc commit) so downstream builds can append them to the wasm link via
+# `-ldflags=-extldflags=$CALICO_TINYGO_CTYPE_COMPAT`. See ctypecompat/README.md.
+COPY ctypecompat/libctypecompat.a /usr/local/lib/ctypecompat/libctypecompat.a
+ENV CALICO_TINYGO_CTYPE_COMPAT=/usr/local/lib/ctypecompat/libctypecompat.a
 
-# TinyGo internally invokes the host `go` toolchain to compile Go packages
-# (parse, type-check, run mod resolution) before lowering through LLVM IR
-# to wasm; the bundled `go` is therefore not optional. Pin both versions
-# in versions.yaml so the toolchain image is reproducible.
-RUN set -eux; \
-    golang_version=$(yq -r .golang.version /etc/versions.yaml); \
-    golang_sha256=$(yq -r ".golang.checksum.sha256.${TARGETARCH}" /etc/versions.yaml); \
-    wget -q -O /tmp/go.tar.gz "https://dl.google.com/go/go${golang_version}.linux-${TARGETARCH}.tar.gz"; \
-    echo "${golang_sha256}  /tmp/go.tar.gz" | sha256sum -c -; \
-    tar -C /usr/local -xzf /tmp/go.tar.gz; \
-    rm /tmp/go.tar.gz
-
-# TinyGo upstream tarball is statically linked (file: ELF static; ldd: not a
-# dynamic executable) so the AlmaLinux 9 base does not need to provide
-# matching libstdc++ / glibc — just untar to /usr/local.
-RUN set -eux; \
-    tinygo_version=$(yq -r .tinygo.version /etc/versions.yaml); \
-    tinygo_sha256=$(yq -r ".tinygo.checksum.sha256.${TARGETARCH}" /etc/versions.yaml); \
-    wget -q -O /tmp/tinygo.tar.gz \
-        "https://github.com/tinygo-org/tinygo/releases/download/v${tinygo_version}/tinygo${tinygo_version}.linux-${TARGETARCH}.tar.gz"; \
-    echo "${tinygo_sha256}  /tmp/tinygo.tar.gz" | sha256sum -c -; \
-    tar -C /usr/local -xzf /tmp/tinygo.tar.gz; \
-    rm /tmp/tinygo.tar.gz
-
+# GOPATH world-writable so downstream builds running as any uid (via
+# `--user $(id -u):$(id -g)`) can populate the module/build caches under it.
 ENV GOPATH=/go
-ENV PATH=/usr/local/go/bin:/usr/local/tinygo/bin:$PATH
-
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+ENV PATH=$PATH:/go/bin
+
+WORKDIR /go
 
 # Recorded for build-log auditability.
 RUN go version && tinygo version
 
-FROM scratch
-
-ENV GOPATH=/go
-ENV PATH=/usr/local/go/bin:/usr/local/tinygo/bin:/go/bin:$PATH
-
-COPY --from=builder / /
-
-WORKDIR /go
+# Restore the base image's non-root default so the image is not root by default.
+USER tinygo

--- a/images/calico-tinygo/test/fixture/main.go
+++ b/images/calico-tinygo/test/fixture/main.go
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // fixture is a TinyGo-vs-go-re2-v1.6 compat check. wasilibs/go-re2 v1.8.0
-// removed TinyGo support upstream (see wasilibs/go-re2#161 — libre2 now
-// requires Abseil with thread synchronization, which TinyGo's libc++ shim
-// does not provide), so coraza-proxy-wasm and gateway/coraza-wasm are
-// permanently frozen on go-re2 v1.6.0. The TinyGo version we ship in this
-// image must continue to link cleanly against v1.6.0's prebuilt wasm
-// static archives (`internal/wasm/{libcre2,libc++,libmimalloc}.a`) for
-// downstream WAF builds to keep working.
+// removed TinyGo support upstream (see wasilibs/go-re2#161): it deleted the
+// prebuilt TinyGo wasm static archives and moved cre2 to a wazero runtime that
+// Envoy's V8 cannot host, so coraza-proxy-wasm and gateway/coraza-wasm are
+// permanently frozen on go-re2 v1.6.0. The TinyGo version we ship in this image
+// must continue to link cleanly against v1.6.0's prebuilt wasm static archives
+// (`internal/wasm/{libcre2,libc++}.a`) for downstream WAF builds to keep working.
 //
 // CI assertion (in .semaphore/semaphore.yml): build this fixture against
 // the just-built calico/tinygo image and count `<- env.cre2_*` imports
@@ -25,11 +24,16 @@
 //     missing-import-at-instantiate failure mode `gateway/coraza-wasm`
 //     would have hit during a downstream WAF rebuild.)
 //
-// pattern + input are read from os.Args so TinyGo's `-opt=2` optimizer
-// cannot prove the calls dead and constant-fold them — without this the
-// optimizer eliminates the wasilibs calls entirely, the static archive
-// never gets pulled in, and the assertion silently passes on a wasm that
-// exercises nothing.
+// Both assertions concern go-re2/cre2 only; every ctype symbol the shim
+// resolves comes from go-re2's archives. go-libinjection is imported to prove
+// it also compiles and links under the shipped TinyGo, but it contributes
+// nothing to the cre2 assertions above.
+//
+// pattern + input are read from os.Args to keep the inputs non-constant, but
+// the wasilibs calls are not dead-code-eliminated regardless: they cross the
+// wasm-import boundary and have observable effects (re2.MustCompile panics on
+// a bad pattern), so `-opt=2` cannot prove them dead even with constant inputs.
+// The static archive is pulled in and the ctype shim is exercised either way.
 package main
 
 import (

--- a/images/calico-tinygo/test/fixture/main.go
+++ b/images/calico-tinygo/test/fixture/main.go
@@ -24,16 +24,10 @@
 //     missing-import-at-instantiate failure mode `gateway/coraza-wasm`
 //     would have hit during a downstream WAF rebuild.)
 //
-// Both assertions concern go-re2/cre2 only; every ctype symbol the shim
-// resolves comes from go-re2's archives. go-libinjection is imported to prove
-// it also compiles and links under the shipped TinyGo, but it contributes
-// nothing to the cre2 assertions above.
-//
-// pattern + input are read from os.Args to keep the inputs non-constant, but
-// the wasilibs calls are not dead-code-eliminated regardless: they cross the
-// wasm-import boundary and have observable effects (re2.MustCompile panics on
-// a bad pattern), so `-opt=2` cannot prove them dead even with constant inputs.
-// The static archive is pulled in and the ctype shim is exercised either way.
+// go-libinjection is a compile/link check only; the CI assertions above cover
+// go-re2/cre2. pattern + input come from os.Args just to keep them non-constant
+// -- `-opt=2` can't dead-code-eliminate the wasilibs calls regardless, since
+// they cross the wasm-import boundary and have observable effects.
 package main
 
 import (

--- a/images/calico-tinygo/versions.yaml
+++ b/images/calico-tinygo/versions.yaml
@@ -1,23 +1,11 @@
-# Wasm output is architecture-agnostic, but the *toolchain* benefits from
-# running native — building on an arm64 host with an arm64 image avoids
-# qemu emulation. TinyGo upstream ships amd64 + arm64 Linux tarballs only
-# (no ppc64le/s390x), so the matrix here matches the upstream coverage.
+# The calico/tinygo image is based on the upstream tinygo/tinygo image (see
+# Dockerfile for why). The TinyGo version below selects that base image tag and
+# is therefore the single version knob for the whole toolchain: the base already
+# bundles a matching Go and a libstdc++/glibc compatible with the TinyGo binary,
+# on both amd64 and arm64, so no separate Go pin or tarball checksums are needed.
+# This selects by tag, not by digest, so it fixes the toolchain version, not the
+# exact bytes. Pin the base by digest here if byte-for-byte reproducibility is
+# required. TinyGo upstream ships amd64 + arm64 only (no ppc64le/s390x), matching
+# this image's arch coverage.
 tinygo:
-  version: 0.34.0
-  checksum:
-    sha256:
-      amd64: 8acd27a39090e1e5c3ca341e81350f813ec6a02bf8090c4fc7c4b1afd4186341
-      arm64: a84b5134dc5144a494e3b7e78579536aca34c77951ddd0b19c300209d8b541e1
-# TinyGo 0.34 caps the host `go` invocation at 1.23.x. Pin Go directly to
-# 1.23.12 (latest compatible patch on the stable channel) instead of
-# bundling a newer Go and forcing GOTOOLCHAIN switching at build time —
-# the latter requires write access to GOPATH/pkg/sumdb which downstream
-# consumers (e.g. gateway/coraza-wasm) cannot reliably provide when the
-# tinygo container runs as the host user via `--user $(id -u):$(id -g)`.
-# When TinyGo relaxes its host-Go upper bound, bump in lockstep.
-golang:
-  version: 1.23.12
-  checksum:
-    sha256:
-      amd64: d3847fef834e9db11bf64e3fb34db9c04db14e068eeb064f49af747010454f90
-      arm64: 52ce172f96e21da53b1ae9079808560d49b02ac86cecfa457217597f9bc28ab3
+  version: 0.39.0


### PR DESCRIPTION
Bumps the `calico/tinygo` toolchain image from TinyGo 0.34.0 (Go 1.23.12) to TinyGo 0.39.0 (Go 1.25.11).

## Why

TinyGo 0.39 is the first release with **Go 1.25 support**, needed by downstream `gateway/coraza-wasm` in `projectcalico/calico` so it can adopt `golang.org/x/net v0.55.0` (CVE-2026-25680), which declares `go 1.25.0`. Under TinyGo 0.34 (a Go 1.23-class toolchain) that module fails to build with `requires go version 1.19 through 1.23, got go1.25`.

The bundled Go is bumped 1.23.12 → 1.25.11 in lockstep — TinyGo 0.39's host `go` invocation is capped at 1.25.x.

## Checksums

TinyGo tarball sha256s verified against the upstream release assets; Go sha256s against the go.dev release manifest. Validated by building the image locally (`docker build --build-arg TARGETARCH=amd64`): `sha256sum -c` passes for both Go and TinyGo, and `go version` / `tinygo version` report `go1.25.11` / `tinygo 0.39.0`.

## Downstream note

TinyGo 0.38 rewrote how it builds its bundled wasi-libc (`builder/wasilibc.go`) and dropped the musl `ctype/*.c` sources. Consumers that link prebuilt wasm archives referencing ctype externs (coraza-wasm's `go-re2` / `nottinygc` archives) must supply those symbols themselves — handled in `gateway/coraza-wasm/tools/ctypecompat/` in the calico PR that consumes this image.