### PR TITLE
[go1.25] Auto-update Go/Kubernetes versions

### DIFF
--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -7,6 +7,6 @@ golang:
       ppc64le: 92a736ac494f4e137a719f986c615c57597d382f90f0988aa2ad80f073c43477
       s390x: 2ddd75feb93aea99bbb1fed08b0eddf2a54601571e4c198e9ba170e26a0d075d
 kubernetes:
-  version: 1.35.7
+  version: 1.35.8
 llvm:
   version: 18.1.8


### PR DESCRIPTION
Automated version update for `go1.25`:

Kubernetes: 1.35.7 -> 1.35.8