### PR TITLE
Remove the calico/go-build pin update trigger

### DIFF
--- a/.semaphore/promotions/calico-go-build.yml
+++ b/.semaphore/promotions/calico-go-build.yml
@@ -51,15 +51,3 @@ blocks:
         - name: Linux multi-arch manifests
           commands:
             - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C images push-calico-go-build-manifests CONFIRM=true; fi
-  - name: Trigger calico/go-build pin updates
-    dependencies:
-      - Publish calico/go-build multi-arch manifests
-    run:
-      when: "tag =~ '^1\\.\\d+\\.\\d+-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d+'"
-    task:
-      secrets:
-        - name: semaphore-api
-      jobs:
-        - name: Auto calico/go-build update
-          commands:
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make update-go-build-pins CONFIRM=true; fi

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,3 @@ image:
 clean:
 	$(MAKE) -C cmd clean
 	$(MAKE) -C images clean
-
-.PHONY: update-go-build-pins
-update-go-build-pins:
-	SEMAPHORE_AUTO_PIN_UPDATE_PROJECT_IDS=$(SEMAPHORE_CALICO_PROJECT_ID) \
-	SEMAPHORE_WORKFLOW_FILE=update-go-build-pins.yml \
-	$(MAKE) semaphore-run-auto-pin-update-workflows


### PR DESCRIPTION
## What / why

Renovate has managed the Calico toolchain versions since projectcalico/calico#12593
(master) and #11931 (release-v3.30), so the pin is now derived rather than written:

```make
GO_BUILD_VER=$(GO_VERSION)-llvm$(LLVM_VERSION)-k8s$(K8S_VERSION:v%=%)
```

This promotion block drove Calico's `update-go-build-pins.yml` workflow, which runs
`update_go_build_pin`. That helper reads the current value with

```sh
grep -E "^GO_BUILD_VER" metadata.mk | cut -d'=' -f2
```

That is textual, not make-expanded, so against the derived form it reads back the
literal string `$(GO_VERSION)-llvm$(LLVM_VERSION)-k8s$(K8S_VERSION:v%`. Any real
version compares greater than that, so the helper always fires and rewrites the
line as a hardcoded literal — undoing exactly what renovate maintains.

## Why nothing depends on it

The promotion only runs on tags matching `1.x.y-llvmA.B.C-k8s1.x.y`. Every Calico
branch that consumes those tags uses the derived form:

| branch | `GO_BUILD_VER` |
|---|---|
| master, release-v3.30 … v3.33 | derived (renovate) |
| release-v3.29 | `v0.94-go1.24` |
| release-v3.28 | `v0.93` |

v3.28 and v3.29 still pin literals, but they predate that tag scheme, so the
trigger never matched for them either.

## Scope

- Drops the `Trigger calico/go-build pin updates` block.
- Drops the `update-go-build-pins` target, which had no other caller. It was the
  only user of the `semaphore-api` secret in this file.
- `SEMAPHORE_CALICO_PROJECT_ID` stays in `Makefile.common`, which other repos consume.
- `calico-base.yml` has no equivalent trigger, so nothing else changes.

Noticed while bumping Calico to Go 1.27 / k8s 1.37 (projectcalico/calico#13613).
