### PR TITLE
Fix the release number of a new version tag

### DIFF
--- a/.github/workflows/create-tag-on-version-change.yml
+++ b/.github/workflows/create-tag-on-version-change.yml
@@ -26,10 +26,20 @@ jobs:
       - name: Create and push new tag (if not exists)
         run: |
           tag_name=${{ steps.generate-tag-name.outputs.tag_name }}
-          count=$(git ls-remote --tags --refs origin "$tag_name*" | grep -c "refs/tags/$tag_name" || :)
-          if [ "$count" -gt 0 ] ; then
-            echo "Git tag $tag_name already exists. Using new tag $tag_name-$count."
-            tag_name="$tag_name-$count"
+          # Changes that leave every compiler version untouched reuse the version
+          # tag with a release number appended, such as <version>-1. Look up the
+          # bare tag and its numeric suffixes only. A "<version>*" glob also
+          # matches the tags of other versions that start with the same text, for
+          # example the k8s1.37.0-rc.1 tags for a k8s1.37.0 tag.
+          release=0
+          for tag in $(git ls-remote --tags --refs origin "$tag_name" "$tag_name-[0-9]*" | sed 's|.*refs/tags/||'); do
+            suffix=${tag#"$tag_name"}
+            suffix=${suffix#-}
+            release=$(( ${suffix:-0} + 1 > release ? ${suffix:-0} + 1 : release ))
+          done
+          if [ "$release" -gt 0 ] ; then
+            echo "Version $tag_name is already tagged. Using new tag $tag_name-$release."
+            tag_name="$tag_name-$release"
           fi
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"


### PR DESCRIPTION
## Problem

`create-tag-on-version-change.yml` counted the existing tags for a version with a prefix glob:

```bash
count=$(git ls-remote --tags --refs origin "$tag_name*" | grep -c "refs/tags/$tag_name" || :)
```

`$tag_name*` also matches the tags of *other* versions whose names start with this one — in particular the pre-release tags of the same Kubernetes version. On `go1.27`:

| Tag | Commit | |
|---|---|---|
| `1.27.0-llvm21.1.8-k8s1.37.0-rc.1` | 650717c (#894) | k8s bumped to 1.37.0-rc.1 |
| `1.27.0-llvm21.1.8-k8s1.37.0-rc.1-1` | 6084bdb (#897) | mockery bump, correct `-1` re-release |
| `1.27.0-llvm21.1.8-k8s1.37.0-2` | ff55eb9 (#902) | k8s bumped to **1.37.0** — the glob matched the two `rc.1` tags, count=2 |

The first tag for k8s 1.37.0 was named `…-k8s1.37.0-2`, so `calico/go-build:1.27.0-llvm21.1.8-k8s1.37.0` was never published. The drift grows with the number of pre-releases: had the `beta.0` tags been on the same Go branch, the first final tag would have been `-5`.

Using the tag *count* as the suffix is a second problem. It is only correct while the numbering has no gaps. In the state above, the next push to `go1.27` computes count=2 and tries to re-create `…-k8s1.37.0-2`, which fails the push.

## Fix

Look up the bare tag and its numeric `-N` suffixes as two separate `git ls-remote` patterns, and take the highest release number plus one:

```bash
release=0
for tag in $(git ls-remote --tags --refs origin "$tag_name" "$tag_name-[0-9]*" | sed 's|.*refs/tags/||'); do
  suffix=${tag#"$tag_name"}
  suffix=${suffix#-}
  release=$(( ${suffix:-0} + 1 > release ? ${suffix:-0} + 1 : release ))
done
```

`git ls-remote` patterns tail-match whole `/`-separated ref components, so `refs/tags/<version>-2` does not match the `<version>` pattern, and a re-release suffix has to start with a digit, so `<version>-rc.1` matches neither pattern.

## Verification

Simulated pushes to `go1.27`, with the `versions.yaml` Kubernetes version on the left:

| k8s version | change | before | after |
|---|---|---|---|
| `1.37.0-beta.0` | bump k8s to beta.0 | `…-k8s1.37.0-beta.0` | `…-k8s1.37.0-beta.0` |
| `1.37.0-beta.0` | bump mockery | `…-beta.0-1` | `…-beta.0-1` |
| `1.37.0-beta.0` | fix Makefile | `…-beta.0-2` | `…-beta.0-2` |
| `1.37.0-rc.1` | bump k8s to rc.1 | `…-k8s1.37.0-rc.1` | `…-k8s1.37.0-rc.1` |
| `1.37.0-rc.1` | bump yq | `…-rc.1-1` | `…-rc.1-1` |
| `1.37.0` | bump k8s to 1.37.0 | **`…-k8s1.37.0-5`** | `…-k8s1.37.0` |
| `1.37.0` | bump crane | `…-k8s1.37.0-6` | `…-k8s1.37.0-1` |
| `1.37.0` | tweak sysroot | `…-k8s1.37.0-7` | `…-k8s1.37.0-2` |

Pre-release sequences are unaffected: each version string, alpha/beta/rc or final, gets its own sequence starting at the bare tag. Also checked against the real tag set and a synthetic one:

- new version, no tags → bare tag
- bare tag only → `-1`
- bare + `-3`, with `-1` deleted → `-4`, no collision
- `-3` and `-10` present → `-11` (numeric, not lexical, comparison)
- `rc.1` and `rc.10` do not cross-match

Two details the step depends on: `--refs` drops the peeled `refs/tags/X^{}` entry that annotated tags also return, and the `release=$(( … ))` assignment form does not trip the `bash -e` that Actions runs `run:` blocks under, unlike a bare `(( … ))` command, which exits 1 when the expression evaluates to 0.

## Follow-up

This workflow runs from the pushed branch's own copy of the file, so the fix takes effect on a `go1.x` branch only once it is cherry-picked there. Every active branch (`go1.23` … `go1.27-k8s1.36`) carries the same buggy line.

The mis-named `1.27.0-llvm21.1.8-k8s1.37.0-2` tag is being replaced with `1.27.0-llvm21.1.8-k8s1.37.0` on the same commit separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)