### PR TITLE
[go1.27] Fix the release number of a new version tag

### DIFF
--- a/.github/workflows/create-tag-on-version-change.yml
+++ b/.github/workflows/create-tag-on-version-change.yml
@@ -26,10 +26,20 @@ jobs:
       - name: Create and push new tag (if not exists)
         run: |
           tag_name=${{ steps.generate-tag-name.outputs.tag_name }}
-          count=$(git ls-remote --tags --refs origin "$tag_name*" | grep -c "refs/tags/$tag_name" || :)
-          if [ "$count" -gt 0 ] ; then
-            echo "Git tag $tag_name already exists. Using new tag $tag_name-$count."
-            tag_name="$tag_name-$count"
+          # Changes that leave every compiler version untouched reuse the version
+          # tag with a release number appended, such as <version>-1. Look up the
+          # bare tag and its numeric suffixes only. A "<version>*" glob also
+          # matches the tags of other versions that start with the same text, for
+          # example the k8s1.37.0-rc.1 tags for a k8s1.37.0 tag.
+          release=0
+          for tag in $(git ls-remote --tags --refs origin "$tag_name" "$tag_name-[0-9]*" | sed 's|.*refs/tags/||'); do
+            suffix=${tag#"$tag_name"}
+            suffix=${suffix#-}
+            release=$(( ${suffix:-0} + 1 > release ? ${suffix:-0} + 1 : release ))
+          done
+          if [ "$release" -gt 0 ] ; then
+            echo "Version $tag_name is already tagged. Using new tag $tag_name-$release."
+            tag_name="$tag_name-$release"
           fi
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"


### PR DESCRIPTION
Cherry-pick of #903.

`create-tag-on-version-change.yml` runs from the pushed branch's own copy of the file, so the fix on master does not change what happens on a push to `go1.27`.

## Why this branch

`go1.27` already went through the failure: pushing the k8s 1.37.0 bump (ff55eb9, #902) matched the two `1.27.0-llvm21.1.8-k8s1.37.0-rc.1` tags with the `"$tag_name*"` glob and created `1.27.0-llvm21.1.8-k8s1.37.0-2` instead of the bare tag. That tag has been replaced by hand with `1.27.0-llvm21.1.8-k8s1.37.0` on the same commit, and the images published from it.

Without this pick the branch repeats the failure on the k8s 1.38 pre-release train, the same way it went `1.36.4` → `1.37.0-rc.1` → `1.37.0`.

## Contents

Unchanged from #903 — the file on this branch was identical to master's, so the pick applies clean and the result is byte-identical to the master version. Look up the bare tag and its numeric `-N` suffixes as two separate `git ls-remote` patterns, and take the highest release number plus one rather than a tag count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)