### PR TITLE
[go1.26-k8s1.37] Fix the release number of a new version tag

### DIFF
--- a/.github/workflows/create-tag-on-version-change.yml
+++ b/.github/workflows/create-tag-on-version-change.yml
@@ -26,10 +26,20 @@ jobs:
       - name: Create and push new tag (if not exists)
         run: |
           tag_name=${{ steps.generate-tag-name.outputs.tag_name }}
-          count=$(git ls-remote --tags --refs origin "$tag_name*" | grep -c "refs/tags/$tag_name" || :)
-          if [ "$count" -gt 0 ] ; then
-            echo "Git tag $tag_name already exists. Using new tag $tag_name-$count."
-            tag_name="$tag_name-$count"
+          # Changes that leave every compiler version untouched reuse the version
+          # tag with a release number appended, such as <version>-1. Look up the
+          # bare tag and its numeric suffixes only. A "<version>*" glob also
+          # matches the tags of other versions that start with the same text, for
+          # example the k8s1.37.0-rc.1 tags for a k8s1.37.0 tag.
+          release=0
+          for tag in $(git ls-remote --tags --refs origin "$tag_name" "$tag_name-[0-9]*" | sed 's|.*refs/tags/||'); do
+            suffix=${tag#"$tag_name"}
+            suffix=${suffix#-}
+            release=$(( ${suffix:-0} + 1 > release ? ${suffix:-0} + 1 : release ))
+          done
+          if [ "$release" -gt 0 ] ; then
+            echo "Version $tag_name is already tagged. Using new tag $tag_name-$release."
+            tag_name="$tag_name-$release"
           fi
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"


### PR DESCRIPTION
Cherry-pick of #903.

`create-tag-on-version-change.yml` runs from the pushed branch's own copy of the file, so the fix on master does not change what happens on a push to this branch.

## Why this branch, before the next k8s bump

This is the only branch still sitting on a Kubernetes pre-release: `1.37.0-rc.1` on go 1.26.5. Three tags already share the prefix of the tag its 1.37.0 bump will want:

```
1.26.5-llvm21.1.8-k8s1.37.0-beta.0
1.26.5-llvm21.1.8-k8s1.37.0-beta.0-1
1.26.5-llvm21.1.8-k8s1.37.0-rc.1
```

Run against the real tag set, the two versions of the step disagree about what that bump produces:

| | tag created for k8s 1.37.0 |
|---|---|
| current | `1.26.5-llvm21.1.8-k8s1.37.0-3` |
| with this pick | `1.26.5-llvm21.1.8-k8s1.37.0` |

`go1.27` hit the same thing on #902 and got `-2`, because it went through only two pre-release tags rather than three. Its tag has been fixed by hand; merging this before the 1.37.0 bump avoids a repeat here.

## Contents

Unchanged from #903 — the file on this branch was identical to master's, so the pick applies clean and the result is byte-identical to the master version. Look up the bare tag and its numeric `-N` suffixes as two separate `git ls-remote` patterns, and take the highest release number plus one rather than a tag count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)