### PR TITLE
[go1.26-k8s1.37] Bump k8s to v1.37.0 release

### DIFF
--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -7,6 +7,6 @@ golang:
       ppc64le: c5d60e2b303bb612f20cd82786594b64874e73b35134025e27d3390bf284ae43
       s390x: 09ce3c504c0323968b75a717244dca4f25cd4cf0443e5ff6bc0bfa74add89fa7
 kubernetes:
-  version: 1.37.0-rc.1
+  version: 1.37.0
 llvm:
   version: 21.1.8


### PR DESCRIPTION
Same change as #902 made on `go1.27`: `kubernetes.version` `1.37.0-rc.1` → `1.37.0`. `https://dl.k8s.io/release/stable-1.37.txt` now returns `v1.37.0`.

Applied as a fresh edit rather than a literal cherry-pick — the diff hunk's context lines are the Go checksums, which differ between `go1.26.5` here and `go1.27.0` there.

## Merge #905 first

Merging this bump is what triggers `create-tag-on-version-change.yml`, and that workflow runs from **this branch's** copy of the file. Against the current file the release is tagged `1.26.5-llvm21.1.8-k8s1.37.0-3`, because the `"$tag_name*"` glob counts the three pre-release tags this branch already produced:

```
1.26.5-llvm21.1.8-k8s1.37.0-beta.0
1.26.5-llvm21.1.8-k8s1.37.0-beta.0-1
1.26.5-llvm21.1.8-k8s1.37.0-rc.1
```

That is how `go1.27` ended up with `1.27.0-llvm21.1.8-k8s1.37.0-2` on #902, a tag that had to be replaced by hand.

With #905 merged first, the release is tagged `1.26.5-llvm21.1.8-k8s1.37.0`, verified by running the patched step against the real tag set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)