### PR TITLE
Auto-update Go/Kubernetes versions on the go1.27 branches

### DIFF
--- a/.github/workflows/check-version-updates.yml
+++ b/.github/workflows/check-version-updates.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         branch:
           - master
+          - go1.27
+          - go1.27-k8s1.36
           - go1.26
           - go1.25
           - go1.25-k8s1.34

--- a/.github/workflows/check-version-updates.yml
+++ b/.github/workflows/check-version-updates.yml
@@ -18,7 +18,6 @@ jobs:
         branch:
           - master
           - go1.27
-          - go1.27-k8s1.36
           - go1.26
           - go1.25
           - go1.25-k8s1.34


### PR DESCRIPTION
Add  `go1.27` to the nightly check-version-updates.